### PR TITLE
mask data_json as sensitive in vault_generic_secret.

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -42,6 +42,7 @@ func genericSecretResource() *schema.Resource {
 				// when disable_read is false for comparing values.
 				StateFunc:    NormalizeDataJSON,
 				ValidateFunc: ValidateDataJSON,
+				Sensitive:    true,				
 			},
 
 			"allow_read": &schema.Schema{


### PR DESCRIPTION
This MR fixes #144 and masks `data_json` as sensitive.